### PR TITLE
Make Plugins pane resizable

### DIFF
--- a/css/plugins-pane.css
+++ b/css/plugins-pane.css
@@ -1,0 +1,20 @@
+.plugins-pane__title {
+  background: #eeeeee;
+  border-bottom: 1px solid #d6d6d6;
+  color: #777;
+  font-variant: small-caps;
+  font-weight: bold;
+  letter-spacing: 1px;
+  line-height: 14px;
+  padding: 6px 0 8px 43px;
+  text-transform: lowercase;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.plugins-pane__body {
+  background: #fff;
+  height: 100%;
+  padding: 10px;
+}

--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -382,12 +382,13 @@ export class GraphiQL extends React.Component {
                 editorTheme={this.props.editorTheme}
                 ResultsTooltip={this.props.ResultsTooltip}
               />
-              {this.props.plugins
-                ? <PluginsPane
-                    plugins={this.props.plugins}
-                  />
-                : ''}
-              {footer}
+              <GraphiQL.Footer>
+                {this.props.plugins
+                  ? <PluginsPane
+                      plugins={this.props.plugins}
+                    />
+                  : ''}
+              </GraphiQL.Footer>
             </div>
           </div>
         </div>

--- a/src/components/PluginsPane.js
+++ b/src/components/PluginsPane.js
@@ -15,13 +15,30 @@ export class PluginsPane extends React.Component {
 
   constructor() {
     super();
+    this.state = {
+      pluginsPaneOpen: true,
+      pluginsPaneHeight: 29,
+    };
+    this.handleResizeStart = this.handleResizeStart.bind(this);
   }
 
   render() {
+    const style = {
+      height: this.state.pluginsPaneOpen ? this.state.pluginsPaneHeight : '29px',
+    };
+
     return (
       <div
       className='plugins-pane'
+      style={style}
       >
+        <div
+          className="plugins-pane__title"
+          style={{cursor: this.state.pluginsPaneOpen ? 'row-resize' : 'n-resize'}}
+          onMouseDown={this.handleResizeStart}
+        >
+          Plugins
+        </div>
         <Tabs>
           {this.tabList()}
           {this.tabPanels()}
@@ -47,4 +64,62 @@ export class PluginsPane extends React.Component {
     });
     return tabs
   }
+
+  handleResizeStart(downEvent) {
+    downEvent.preventDefault();
+
+    let didMove = false;
+    const wasOpen = this.state.pluginsPaneOpen;
+    const hadHeight = this.state.pluginsPaneHeight;
+    const offset = downEvent.clientY - getTop(downEvent.target);
+
+    let onMouseUp = () => {
+      if (!didMove) {
+        this.setState({pluginsPaneOpen: !wasOpen});
+      }
+
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+      onMouseMove = null;
+      onMouseUp = null;
+    };
+
+    let onMouseMove = (moveEvent) => {
+      if (moveEvent.buttons === 0) {
+        return onMouseUp();
+      }
+
+      didMove = true;
+
+      const editorBar = document.querySelector('.editorBar');
+      const topSize = moveEvent.clientY - getTop(editorBar) - offset;
+      const bottomSize = editorBar.clientHeight - topSize - 30;
+
+
+      if (bottomSize < 60) {
+        this.setState({
+          pluginsPaneOpen: false,
+          pluginsPaneHeight: hadHeight,
+        });
+      } else {
+        this.setState({
+          pluginsPaneOpen: true,
+          pluginsPaneHeight: bottomSize,
+        });
+      }
+    };
+
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+  }
+}
+
+function getTop(initialElem) {
+  let pt = 0;
+  let elem = initialElem;
+  while (elem.offsetParent) {
+    pt += elem.offsetTop;
+    elem = elem.offsetParent;
+  }
+  return pt;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1083,10 +1083,6 @@ chokidar@^1.0.0, chokidar@^1.6.1:
   optionalDependencies:
     fsevents "^1.0.0"
 
-ci-info@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.0.0.tgz#dc5285f2b4e251821683681c381c3388f46ec534"
-
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.3.tgz#eeabf194419ce900da3018c207d212f2a6df0a07"
@@ -2328,14 +2324,6 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
 
-husky@^0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.0.tgz#d0115459d824e7cc67dbc23231935ba9cfdf0989"
-  dependencies:
-    is-ci "^1.0.10"
-    normalize-path "^1.0.0"
-    strip-indent "^2.0.0"
-
 iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
@@ -2468,12 +2456,6 @@ is-builtin-module@^1.0.0:
 is-callable@^1.1.1, is-callable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
-
-is-ci@^1.0.10:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.0.10.tgz#f739336b2632365061a9d48270cd56ae3369318e"
-  dependencies:
-    ci-info "^1.0.0"
 
 is-date-object@^1.0.1:
   version "1.0.1"
@@ -3142,10 +3124,6 @@ normalize-package-data@^2.3.2:
     is-builtin-module "^1.0.0"
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
-
-normalize-path@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
 
 normalize-path@^2.0.1:
   version "2.1.1"
@@ -4211,10 +4189,6 @@ strip-bom@^3.0.0:
 strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
-
-strip-indent@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
 
 strip-json-comments@~2.0.1:
   version "2.0.1"


### PR DESCRIPTION
This makes the plugins pane (introduced in #1) resizable.

![screencast 2018-01-16 15-05-14](https://user-images.githubusercontent.com/4921652/35009870-060078aa-facf-11e7-949a-164639ba919e.gif)
[Better quality without the weird colours](https://drive.google.com/file/d/19LfIwnwNtu4ZKXWw4sL3I6s4Dv7M2Hdj/view?usp=sharing)

One thing to note is that this required using the `GraphiQL.Footer` component as a wrapper around our new `PluginsPane` component. It appears the `GraphiQL.Footer` component was built for this kind of thing.

cc @ismail-syed @DerekStride 