### PR TITLE
Allow plugin rendering logic to exist outside Graphiql

### DIFF
--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -69,9 +69,9 @@ export class GraphiQL extends React.Component {
     plugins: PropTypes.arrayOf(
       PropTypes.shape({
         title: PropTypes.string,
-        content: PropTypes.any
-      })
-    )
+        plugin: PropTypes.func.isRequired,
+      }),
+    ),
   };
 
   constructor(props) {
@@ -382,13 +382,14 @@ export class GraphiQL extends React.Component {
                 editorTheme={this.props.editorTheme}
                 ResultsTooltip={this.props.ResultsTooltip}
               />
-              <GraphiQL.Footer>
-                {this.props.plugins
-                  ? <PluginsPane
+              {this.props.plugins
+                ? <GraphiQL.Footer>
+                    <PluginsPane
                       plugins={this.props.plugins}
+                      value={this.state.response}
                     />
-                  : ''}
-              </GraphiQL.Footer>
+                  </GraphiQL.Footer>
+                : footer}
             </div>
           </div>
         </div>

--- a/src/components/PluginsPane.js
+++ b/src/components/PluginsPane.js
@@ -4,14 +4,17 @@ import PropTypes from 'prop-types';
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
 
 export class PluginsPane extends React.Component {
-  static propTypes = [{
-    plugins: PropTypes.arrayOf(
-      PropTypes.shape({
-        title: PropTypes.string,
-        content: PropTypes.any
-      })
-    )
-  }];
+  static propTypes = [
+    {
+      plugins: PropTypes.arrayOf(
+        PropTypes.shape({
+          title: PropTypes.string,
+          plugin: PropTypes.func.isRequired,
+        }),
+      ),
+      value: PropTypes.string,
+    },
+  ];
 
   constructor() {
     super();
@@ -24,20 +27,20 @@ export class PluginsPane extends React.Component {
 
   render() {
     const style = {
-      height: this.state.pluginsPaneOpen ? this.state.pluginsPaneHeight : '29px',
+      height: this.state.pluginsPaneOpen
+        ? this.state.pluginsPaneHeight
+        : '29px',
     };
 
     return (
-      <div
-      className='plugins-pane'
-      style={style}
-      >
+      <div className="plugins-pane" style={style}>
         <div
-          className="plugins-pane__title"
-          style={{cursor: this.state.pluginsPaneOpen ? 'row-resize' : 'n-resize'}}
-          onMouseDown={this.handleResizeStart}
-        >
-          Plugins
+          className="plugins-pane__title variable-editor-title"
+          style={{
+            cursor: this.state.pluginsPaneOpen ? 'row-resize' : 'n-resize',
+          }}
+          onMouseDown={this.handleResizeStart}>
+          {'Plugins'}
         </div>
         <Tabs>
           {this.tabList()}
@@ -49,20 +52,22 @@ export class PluginsPane extends React.Component {
 
   tabList() {
     const tabs = this.props.plugins.map((plugin, id) =>
-      <Tab key={id}> {plugin.title} </Tab>
+      <Tab key={id}> {plugin.title} </Tab>,
     );
-    return (
-      <TabList>{tabs}</TabList>
-    )
+    return <TabList>{tabs}</TabList>;
   }
 
   tabPanels() {
-    const tabs = this.props.plugins.map((plugin, id) => {
+    const tabs = this.props.plugins.map((aPlugin, id) => {
+      const { plugin } = aPlugin;
+      const viewer = plugin && plugin(this.props.value);
       return (
-        <TabPanel key={id}> {plugin.content} </TabPanel>
+        <TabPanel key={id}>
+          {viewer}
+        </TabPanel>
       );
     });
-    return tabs
+    return tabs;
   }
 
   handleResizeStart(downEvent) {
@@ -75,7 +80,7 @@ export class PluginsPane extends React.Component {
 
     let onMouseUp = () => {
       if (!didMove) {
-        this.setState({pluginsPaneOpen: !wasOpen});
+        this.setState({ pluginsPaneOpen: !wasOpen });
       }
 
       document.removeEventListener('mousemove', onMouseMove);
@@ -84,7 +89,7 @@ export class PluginsPane extends React.Component {
       onMouseUp = null;
     };
 
-    let onMouseMove = (moveEvent) => {
+    let onMouseMove = moveEvent => {
       if (moveEvent.buttons === 0) {
         return onMouseUp();
       }
@@ -94,7 +99,6 @@ export class PluginsPane extends React.Component {
       const editorBar = document.querySelector('.editorBar');
       const topSize = moveEvent.clientY - getTop(editorBar) - offset;
       const bottomSize = editorBar.clientHeight - topSize - 30;
-
 
       if (bottomSize < 60) {
         this.setState({

--- a/test/index.html
+++ b/test/index.html
@@ -26,6 +26,8 @@
     <script src="./vendor/react-15.4.2.js"></script>
     <script src="./vendor/react-dom-15.4.2.js"></script>
 
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.23/browser.js"></script>
+
     <!-- Load each file individually for better debugging  -->
     <!-- Note that in practice, a compiled graphiql.css is included -->
     <link rel="stylesheet" href="css/app.css" />
@@ -45,7 +47,7 @@
   </head>
   <body>
     <div id="graphiql">Loading...</div>
-    <script>
+    <script type="text/babel">
 
       /**
        * This GraphiQL example illustrates how to use some of GraphiQL's props
@@ -126,6 +128,17 @@
         });
       }
 
+      const viewer = function(results) {
+        if (results) {
+          return (
+            <div>
+              <h3>An example plugin</h3>
+              <div> {results} </div>
+            </div>
+          )
+        }
+      };
+
       // Render <GraphiQL /> into the body.
       ReactDOM.render(
         React.createElement(GraphiQL, {
@@ -138,17 +151,9 @@
           onEditOperationName: onEditOperationName,
           plugins: [
             {
-              title: 'Analysis',
-              content: 'Analysis content',
+              title: 'Raw',
+              plugin: viewer,
             },
-            {
-              title: 'Metrics',
-              content: 'Metrics content',
-            },
-            {
-              title: 'Visualizations',
-              content: 'Visualization content',
-            }
           ]
         }),
         document.getElementById('graphiql')


### PR DESCRIPTION
This PR allows for the rendering logic of the plugin view to be done from outside the GraphiQL core codebase. 

<img width="1053" alt="screen shot 2018-02-11 at 4 55 00 pm" src="https://user-images.githubusercontent.com/6130700/36079065-12a4daaa-0f4d-11e8-8c3c-e4761f62911d.png">
