### PR TITLE
Use component with render prop instead of function

### DIFF
--- a/src/components/PluginsPane.js
+++ b/src/components/PluginsPane.js
@@ -8,8 +8,8 @@ export class PluginsPane extends React.Component {
     {
       plugins: PropTypes.arrayOf(
         PropTypes.shape({
-          title: PropTypes.string,
-          plugin: PropTypes.func.isRequired,
+          title: PropTypes.string.isRequired,
+          plugin: PropTypes.any.isRequired,
         }),
       ),
       value: PropTypes.string,
@@ -59,11 +59,13 @@ export class PluginsPane extends React.Component {
 
   tabPanels() {
     const tabs = this.props.plugins.map((aPlugin, id) => {
-      const { plugin } = aPlugin;
-      const viewer = plugin && plugin(this.props.value);
+      const { props } = aPlugin.plugin;
+      const error = <div> {'Plugin does not include a render prop'}</div>;
+      const view = props.render ? props.render(this.props.value) : error;
+
       return (
         <TabPanel key={id}>
-          {viewer}
+          {view}
         </TabPanel>
       );
     });

--- a/test/index.html
+++ b/test/index.html
@@ -139,6 +139,8 @@
         }
       };
 
+      const Plugin = <div />;
+
       // Render <GraphiQL /> into the body.
       ReactDOM.render(
         React.createElement(GraphiQL, {
@@ -152,7 +154,7 @@
           plugins: [
             {
               title: 'Raw',
-              plugin: viewer,
+              plugin: <Plugin render={viewer} />,
             },
           ]
         }),


### PR DESCRIPTION
PluginsPane accepts a component with a render prop instead of just a function.This provides more flexibility for plugin components. [Render Props](https://reactjs.org/docs/render-props.html#use-render-props-for-cross-cutting-concerns) is a fancy new-ish react pattern - read the docs for more details. 

> The term “render prop” refers to a simple technique for sharing code between React components using a prop whose value is a function.